### PR TITLE
alter regex to support aws key aliases

### DIFF
--- a/bin/es.go
+++ b/bin/es.go
@@ -99,7 +99,7 @@ func main() {
 		Short: "encrypt environment variables",
 		PreRun: func(cmd *cobra.Command, args []string) {
 
-			matcher := regexp.MustCompile(`arn\:aws\:kms\:([a-z0-9-]+):\d+\:key\/([a-f0-9\-]+)`)
+			matcher := regexp.MustCompile(`arn\:aws\:kms\:([a-z0-9-]+):\d+\:(key\/[a-f0-9\-]+|alias\/[a-zA-Z0-9:\/_-]+$)`)
 			matches := matcher.FindAllStringSubmatch(*arn, -1)
 
 			if len(matches) > 0 {


### PR DESCRIPTION
This alters the regex to search for a valid alias too.
Can you build and upload a release when merged please? https://github.com/kreuzwerker/envsec/issues/8